### PR TITLE
Various fixes to better facilitate Gates Edge

### DIFF
--- a/src/bicep/modules/localNetworkGateway.bicep
+++ b/src/bicep/modules/localNetworkGateway.bicep
@@ -7,7 +7,7 @@ param remoteNetworkAddressPrefixes array
 param remoteGatewayPublicIpAddress string
 //param tags object = {}
 
-resource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2021-05-01' = {
+resource localNetworkGateway 'Microsoft.Network/localNetworkGateways@2020-06-01' = {
   name: name
   location: location
   properties: {

--- a/src/bicep/modules/spokeNetwork.bicep
+++ b/src/bicep/modules/spokeNetwork.bicep
@@ -9,6 +9,7 @@ param networkSecurityGroupName string
 param networkSecurityGroupRules array
 param subnetName string
 param subnetAddressPrefix string
+param customDNSArray array = []
 param firewallPrivateIPAddress string = ''
 param routeTableName string = '${subnetName}-routetable'
 param routeTableRouteName string = 'default_route'
@@ -48,6 +49,7 @@ module virtualNetwork './virtualNetwork.bicep' = {
     name: virtualNetworkName
     location: location
     tags: tags
+    customDNSArray: customDNSArray
     addressPrefix: virtualNetworkAddressPrefix
     subnets: [
       {

--- a/src/bicep/modules/virtualNetwork.bicep
+++ b/src/bicep/modules/virtualNetwork.bicep
@@ -4,6 +4,7 @@
 param name string
 param location string
 param tags object = {}
+param customDNSArray array = []
 param addressPrefix string
 param subnets array
 
@@ -16,6 +17,9 @@ resource virtualNetwork 'Microsoft.Network/virtualNetworks@2018-11-01' = {
       addressPrefixes: [
         addressPrefix
       ]
+    }
+    dhcpOptions: {
+      dnsServers: customDNSArray
     }
     subnets: subnets
   }

--- a/src/bicep/modules/virtualNetworkPeering.bicep
+++ b/src/bicep/modules/virtualNetworkPeering.bicep
@@ -4,7 +4,10 @@
 param localVirtualNetworkName string
 param remoteVirtualNetworkName string
 param remoteResourceGroupName string
+param allowVirtualNetworkAccess bool = false
 param allowForwardedTraffic bool = false
+param allowGatewayTransit bool = false
+param useRemoteGateways bool = false
 
 resource localVirtualNetwork 'Microsoft.Network/virtualNetworks@2018-11-01' existing = {
   name: localVirtualNetworkName
@@ -18,7 +21,10 @@ resource remoteVirtualNetwork 'Microsoft.Network/virtualNetworks@2018-11-01' exi
 resource virtualNetworkPeering 'Microsoft.Network/virtualNetworks/virtualNetworkPeerings@2018-11-01' = {
   name: '${localVirtualNetwork.name}/to-${remoteVirtualNetwork.name}'
   properties: {
+    allowVirtualNetworkAccess: allowVirtualNetworkAccess
     allowForwardedTraffic: allowForwardedTraffic
+    allowGatewayTransit: allowGatewayTransit
+    useRemoteGateways: useRemoteGateways
     remoteVirtualNetwork: {
       id: remoteVirtualNetwork.id
     }


### PR DESCRIPTION
# Description
Incorporates various fixes to better facilitate Gates Edge including:
- Sets hub/spoke peering configuration to "use gateway" and "allow forwarded traffic"
- Creates parameter to pass in a custom DNS array (e.g. to reference the DC in the Sidecar at hub and spoke vnets)
- Removes reference to the internal/external subnets in the hub network
- Update to the LocalNetworkGateway ARM API version to resolve a warning

## Issue reference

The issue this PR will close: #[issue number]

## Checklist

Please make sure you've completed the relevant tasks for this PR out of the following list:

* [x] All acceptance criteria in the backlog item are met
* [x] The documentation is updated to cover any new or changed features
* [x] Manual tests have passed
* [x] Relevant issues are linked to this PR
